### PR TITLE
Make pinout table display correctly as Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Firmware for the specific panel was found here:- http://www.buydisplay.com/defau
 Use source code from wolfmanjm : https://github.com/wolfmanjm/GSL1680
 
 pin | function  | Arduino Uno
------------------------------
+----|-----------|------------
 1   | SCL       | A5
 2   | SDA       | A4
 3   | VDD (3v3) | 3v3


### PR DESCRIPTION
Previously the pinout table in README.md was not correctly rendered.

Before:
![clipboard01](https://user-images.githubusercontent.com/8572152/29733941-84aa60fe-89a4-11e7-886b-d68c0b7fecb0.jpg)

After:

pin | function  | Arduino Uno
----|-----------|------------
1   | SCL       | A5
2   | SDA       | A4
3   | VDD (3v3) | 3v3
4   | Wake      | 4
5   | Int       | 2
6   | Gnd       | gnd